### PR TITLE
MWPW-207303: fix(merch,router-marquee): keep inline mas-field and dedup paragraphs

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1763,6 +1763,16 @@ function unwrapInlineWrappers(masField) {
   }
 }
 
+function unwrapSoleAnchorParagraph(content) {
+  const isWhitespace = (node) => node.nodeType === Node.TEXT_NODE && !node.textContent.trim();
+  const [wrapper, ...rest] = [...content.childNodes].filter((node) => !isWhitespace(node));
+  if (rest.length || wrapper?.tagName !== 'P') return;
+  const inner = [...wrapper.childNodes].filter((node) => !isWhitespace(node));
+  if (inner.length === 1 && inner[0].nodeName === 'A') {
+    wrapper.replaceWith(...wrapper.childNodes);
+  }
+}
+
 function normalizeBlockFieldWrappers(masField) {
   const content = masField.querySelector(':scope > [data-role="mas-field-content"]');
   if (!content?.querySelector(BLOCK_CONTENT_SELECTOR)) return;
@@ -1931,6 +1941,10 @@ async function createInlineField(el, options) {
 
   el.replaceWith(masField);
   await checkFieldReady(masField, options.fragment);
+  if (options.field?.startsWith('ctas')) {
+    const preContent = masField.querySelector(':scope > [data-role="mas-field-content"]');
+    if (preContent) unwrapSoleAnchorParagraph(preContent);
+  }
   normalizeBlockFieldWrappers(masField);
   await localizePreviewLinks(masField);
 

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1762,17 +1762,6 @@ function unwrapInlineWrappers(masField) {
     parent = masField.parentElement;
   }
 }
-
-function unwrapSoleAnchorParagraph(content) {
-  const isWhitespace = (node) => node.nodeType === Node.TEXT_NODE && !node.textContent.trim();
-  const [wrapper, ...rest] = [...content.childNodes].filter((node) => !isWhitespace(node));
-  if (rest.length || wrapper?.tagName !== 'P') return;
-  const inner = [...wrapper.childNodes].filter((node) => !isWhitespace(node));
-  if (inner.length === 1 && inner[0].nodeName === 'A') {
-    wrapper.replaceWith(...wrapper.childNodes);
-  }
-}
-
 function normalizeBlockFieldWrappers(masField) {
   const content = masField.querySelector(':scope > [data-role="mas-field-content"]');
   if (!content?.querySelector(BLOCK_CONTENT_SELECTOR)) return;
@@ -1803,9 +1792,8 @@ function ensureInlinePriceStyle(content) {
   }
 }
 
-// A CTA field and its card's price field resolve independently. Hold the CTA's
-// container until the price mas-field is ready so the CTA can't paint above an
-// unresolved price (reveal anyway after FIELD_TIMEOUT).
+// Hold the CTA's container hidden until its card's price mas-field is ready, so the CTA
+// can't paint above an unresolved price (reveals anyway after FIELD_TIMEOUT).
 export function holdCtaUntilPrice(container) {
   if (!container?.style) return;
   let scope = container.parentElement;
@@ -1829,6 +1817,11 @@ export function holdCtaUntilPrice(container) {
 function decorateInlineCtas(masField, content) {
   const container = masField.closest('p, div');
   holdCtaUntilPrice(container);
+  // router-marquee styles CTAs itself via plain em/strong/a selectors and doesn't need
+  // mas-field to stay attached, so fully unwrap it there instead of keeping it in the DOM --
+  // otherwise a later, independent re-render from the external mas-field component injects a
+  // stray duplicate content span onto it.
+  const selfDecoratesCtas = !!container?.closest('.router-marquee');
 
   // The block this CTA belongs to (direct child of a section). Bounds the sibling
   // lookup so a foreign block's button can't dictate this CTA's size.
@@ -1866,8 +1859,6 @@ function decorateInlineCtas(masField, content) {
       size = (blockSize === 'large' || blockSize === 'xlarge') ? 'button-xl' : 'button-l';
     }
   }
-  ensureInlinePriceStyle(content);
-
   if (masField.merchLink) {
     [...masField.merchLink.matchAll(/&_button-([a-zA-Z-]+)/g)].forEach((match) => {
       content.querySelectorAll('a').forEach((link) => {
@@ -1876,27 +1867,38 @@ function decorateInlineCtas(masField, content) {
     });
   }
 
-  // Keep mas-field as the CTA's ancestor (not unwrap) so its promo/id context survives by
-  // structure. Re-nest to wrap the em/strong so decorateButtons' 'em a'/'strong a' still match.
-  const hoisted = [...content.childNodes].find((node) => node.nodeType === Node.ELEMENT_NODE);
-  let outer = masField;
-  while (outer.parentElement?.matches?.(INLINE_WRAPPER_SELECTOR)
-    && hasOnlyTargetContent(outer.parentElement, outer)) {
-    outer = outer.parentElement;
-  }
-  if (outer === masField) {
-    masField.replaceChildren(...content.childNodes);
-  } else {
+  let hoisted;
+  if (selfDecoratesCtas) {
+    upgradeCommerceLinks(content);
+    ensureInlinePriceStyle(content);
+    hoisted = [...content.childNodes].find((node) => node.nodeType === Node.ELEMENT_NODE);
     masField.replaceWith(...content.childNodes);
-    outer.replaceWith(masField);
-    masField.append(outer);
-    // Drop the emptied content span so a re-render can't reuse it ahead of the decorated CTA.
-    content.remove();
+  } else {
+    // Keep mas-field as the CTA's ancestor so decorateButtons' 'em a'/'strong a' still match
+    // once re-nested, and its promo/id context survives by structure. Move content while it's
+    // still a plain <a>; upgrading to is="checkout-link" is deferred until it settles into its
+    // final position so the custom element only connects once.
+    const innerWrapper = masField.parentElement;
+    let outer = masField;
+    while (outer.parentElement?.matches?.(INLINE_WRAPPER_SELECTOR)
+      && hasOnlyTargetContent(outer.parentElement, outer)) {
+      outer = outer.parentElement;
+    }
+    if (outer === masField) {
+      masField.replaceChildren(...content.childNodes);
+    } else {
+      outer.replaceWith(masField);
+      innerWrapper.append(...content.childNodes);
+      masField.append(outer);
+      // Drop the emptied content span so a re-render can't reuse it ahead of the decorated CTA.
+      content.remove();
+    }
+    upgradeCommerceLinks(masField);
+    ensureInlinePriceStyle(masField);
+    hoisted = masField.querySelector('a, button');
   }
 
-  // router-marquee styles its own CTAs after resolution (primary = em>strong).
-  // decorateButtons would strip the <strong> and misclassify them as outline.
-  const selfDecoratesCtas = container?.closest('.router-marquee');
+  // decorateButtons would strip the <strong> and misclassify router-marquee's CTAs as outline.
   const pendingCTAs = container?.querySelectorAll('em > mas-field, strong > mas-field');
   if (container && !pendingCTAs?.length && !selfDecoratesCtas) {
     decorateButtons(container, size);
@@ -1920,8 +1922,6 @@ function watchMasFieldCtas() {
     const content = mf.querySelector(':scope > [data-role="mas-field-content"]');
     // Same gate createInline uses: an inline CTA anchor, not block-level content.
     if (content?.querySelector('a') && !content.querySelector(BLOCK_CONTENT_SELECTOR)) {
-      // Upgrade to checkout-link before hoisting, else the late CTA never hydrates.
-      upgradeCommerceLinks(content);
       await decorateContentLinks(content);
       decorateInlineCtas(mf, content);
     }
@@ -1941,19 +1941,11 @@ async function createInlineField(el, options) {
 
   el.replaceWith(masField);
   await checkFieldReady(masField, options.fragment);
-  if (options.field?.startsWith('ctas')) {
-    const preContent = masField.querySelector(':scope > [data-role="mas-field-content"]');
-    if (preContent) unwrapSoleAnchorParagraph(preContent);
-  }
   normalizeBlockFieldWrappers(masField);
   await localizePreviewLinks(masField);
 
   const content = masField.querySelector(':scope > [data-role="mas-field-content"]');
   if (!content) return masField;
-
-  // Upgrade any plain commerce elements (missing `is`) so the commerce service resolves
-  // them. Applies to both CTA (<a>) and price (<span>) fields.
-  upgradeCommerceLinks(content);
 
   await decorateContentLinks(content);
 
@@ -1961,6 +1953,9 @@ async function createInlineField(el, options) {
   if (content.querySelector('a') && !content.querySelector(BLOCK_CONTENT_SELECTOR)) {
     return decorateInlineCtas(masField, content) ?? masField;
   }
+
+  // Non-CTA (block) fields never move after this point, so upgrading now is safe.
+  upgradeCommerceLinks(content);
   return masField;
 }
 

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1691,6 +1691,15 @@ const HEADING_SELECTOR = 'h1, h2, h3, h4, h5, h6';
 const BLOCK_CONTENT_SELECTOR = `${HEADING_SELECTOR}, p, div, ul, ol, table, blockquote, pre, figure, section, article, hr`;
 const INLINE_WRAPPER_SELECTOR = 'strong, em, span, b, i, u, small, mark';
 
+// A description with a link (e.g. "save 40%. Terms apply") isn't a button (MWPW-207084).
+function isCtaFieldContent(content) {
+  if (!content || content.querySelector(BLOCK_CONTENT_SELECTOR)) return false;
+  const anchors = [...content.querySelectorAll('a')];
+  if (!anchors.length) return false;
+  const strip = (text) => text.replace(/\s+/g, '');
+  return strip(content.textContent) === strip(anchors.map((a) => a.textContent).join(''));
+}
+
 /**
  * Upgrades plain commerce elements (missing `is` attribute) to their proper
  * customized built-in equivalents so the commerce service resolves them.
@@ -1908,8 +1917,7 @@ function watchMasFieldCtas() {
   document.addEventListener('mas:ready', async ({ target: mf }) => {
     if (mf?.tagName !== 'MAS-FIELD' || !mf.closest('em, strong')) return;
     const content = mf.querySelector(':scope > [data-role="mas-field-content"]');
-    // Same gate createInline uses: an inline CTA anchor, not block-level content.
-    if (content?.querySelector('a') && !content.querySelector(BLOCK_CONTENT_SELECTOR)) {
+    if (isCtaFieldContent(content)) {
       // Upgrade to checkout-link before hoisting, else the late CTA never hydrates.
       upgradeCommerceLinks(content);
       await decorateContentLinks(content);
@@ -1944,7 +1952,7 @@ async function createInlineField(el, options) {
   await decorateContentLinks(content);
 
   // Inline CTAs: hoist the anchor into the authored em/strong and let decorateButtons style it.
-  if (content.querySelector('a') && !content.querySelector(BLOCK_CONTENT_SELECTOR)) {
+  if (isCtaFieldContent(content)) {
     return decorateInlineCtas(masField, content) ?? masField;
   }
   return masField;

--- a/libs/c2/blocks/router-marquee/router-marquee.css
+++ b/libs/c2/blocks/router-marquee/router-marquee.css
@@ -531,3 +531,8 @@
   white-space: nowrap;
   border: 0;
 }
+
+/* Rejoin parser-split nested paragraphs into one line. */
+.router-marquee mas-field > [data-role="mas-field-content"] p {
+  display: inline;
+}

--- a/libs/c2/blocks/router-marquee/router-marquee.js
+++ b/libs/c2/blocks/router-marquee/router-marquee.js
@@ -148,7 +148,8 @@ const decorateText = (textCol) => {
   const icon = textCol.querySelector('p a[href*=".svg"]');
   const label = textCol.querySelector(':scope > p:has(a[href*=".svg"]) + p');
   const cta = textCol.querySelector('p:has(em)');
-  const body = [...textCol.querySelectorAll('p')]
+  // Direct children only: skip <p>s a mas-field renders inside itself.
+  const body = [...textCol.querySelectorAll(':scope > p')]
     .filter((p) => [eyebrow, icon?.closest('p'), label, cta].every((x) => x !== p));
 
   if (!body.length) return;

--- a/libs/c2/blocks/router-marquee/router-marquee.js
+++ b/libs/c2/blocks/router-marquee/router-marquee.js
@@ -145,11 +145,11 @@ const decorateText = (textCol) => {
   heading?.previousElementSibling?.classList.add('rm-eyebrow');
 
   const eyebrow = textCol.querySelector('.rm-eyebrow');
-  const icon = textCol.querySelector('p a[href*=".svg"]');
-  const label = textCol.querySelector(':scope > p:has(a[href*=".svg"]) + p');
-  const cta = textCol.querySelector('p:has(em)');
-  const body = [...textCol.querySelectorAll('p')]
-    .filter((p) => [eyebrow, icon?.closest('p'), label, cta].every((x) => x !== p));
+  const icon = textCol.querySelector(':scope > p:has(img[src*=".svg"])');
+  const label = textCol.querySelector(':scope > p:has(img[src*=".svg"]) + p');
+  const cta = textCol.querySelector(':scope > p:has(> em)');
+  const body = [...textCol.querySelectorAll(':scope > p')]
+    .filter((p) => [eyebrow, icon, label, cta].every((x) => x !== p));
 
   if (!body.length) return;
   const bodyEl = createTag('div', { class: 'rm-body' });
@@ -158,7 +158,7 @@ const decorateText = (textCol) => {
 };
 
 const decorateCtas = (textCol) => {
-  const cta = textCol.querySelector('p:has(em)');
+  const cta = textCol.querySelector(':scope > p:has(> em)');
   if (!cta) return;
   cta.classList.add('rm-ctas', 'dark', 'action-area');
   const primary = cta.querySelector('em > strong a');
@@ -238,14 +238,14 @@ const decorateSlide = (slide) => {
 const buildCard = (slide) => {
   const icon = [...slide.querySelectorAll('p')]
     .find((p) => p.querySelector('img[src*=".svg"]'));
-  const label = icon.nextElementSibling;
-  const iconSrc = getFederatedUrl(icon.querySelector('img[src*=".svg"]')?.getAttribute('src'));
-  const labelText = label?.textContent.trim();
+  const label = icon?.nextElementSibling;
+  const iconSrc = icon && getFederatedUrl(icon.querySelector('img[src*=".svg"]')?.getAttribute('src'));
+  const labelText = (label?.textContent ?? slide.querySelector('.rm-title')?.textContent ?? '').trim();
   const href = label?.querySelector('a')?.getAttribute('href') || '';
   const eyebrowText = slide.querySelector('.rm-eyebrow')?.textContent.trim();
-  const ariaLabel = eyebrowText ? `${eyebrowText}, ${labelText}` : labelText;
+  const ariaLabel = [eyebrowText, labelText].filter(Boolean).join(', ');
 
-  icon.remove();
+  icon?.remove();
   label?.remove();
 
   const card = createTag('a', {
@@ -256,7 +256,7 @@ const buildCard = (slide) => {
     'aria-selected': 'false',
   });
   card.replaceChildren(
-    createTag('img', { class: 'rm-card-icon', src: iconSrc, alt: labelText, loading: 'lazy' }),
+    ...(iconSrc ? [createTag('img', { class: 'rm-card-icon', src: iconSrc, alt: labelText, loading: 'lazy' })] : []),
     createTag('div', { class: 'rm-card-content' }, [
       createTag('span', { class: 'rm-card-label' }, labelText),
       createTag('span', { class: 'rm-card-chevron', 'aria-hidden': 'true' }, CHEVRON_SVG),

--- a/libs/c2/blocks/router-marquee/router-marquee.js
+++ b/libs/c2/blocks/router-marquee/router-marquee.js
@@ -147,7 +147,7 @@ const decorateText = (textCol) => {
   const eyebrow = textCol.querySelector('.rm-eyebrow');
   const icon = textCol.querySelector('p a[href*=".svg"]');
   const label = textCol.querySelector(':scope > p:has(a[href*=".svg"]) + p');
-  const cta = textCol.querySelector('p:has(em)');
+  const cta = textCol.querySelector(':scope > p:has(> em)');
   // Direct children only: skip <p>s a mas-field renders inside itself.
   const body = [...textCol.querySelectorAll(':scope > p')]
     .filter((p) => [eyebrow, icon?.closest('p'), label, cta].every((x) => x !== p));

--- a/test/blocks/merch/mas-field.test.js
+++ b/test/blocks/merch/mas-field.test.js
@@ -17,6 +17,9 @@ if (!customElements.get('mas-field')) {
         const field = this.getAttribute('field');
         if (field === 'description') {
           content.innerHTML = '<h3><strong>Resolved description</strong></h3><a href="https://www.adobe.com/">See terms</a><a href="https://main--milo--adobecom.aem.live/test/fragments/modal#cardmodal">Open modal</a>';
+        } else if (field === 'description-inline') {
+          // Copy with an inline link and no block wrapper — must stay a description (MWPW-207084).
+          content.innerHTML = 'Save 40% off your first year. <a href="https://www.adobe.com/terms">Terms apply</a>';
         } else if (field === 'ctas') {
           content.innerHTML = '<strong><a href="https://www.adobe.com/">Buy now</a></strong><em><a href="https://main--milo--adobecom.aem.page/some/test/page">Go</a></em>';
         } else if (field === 'ctas-checkout') {
@@ -161,6 +164,22 @@ describe('mas-field', () => {
       const modalLink = document.querySelector('mas-field a[href="#cardmodal"]');
       expect(modalLink.classList.contains('modal')).to.be.true;
       expect(modalLink.getAttribute('data-modal-path')).to.equal('/test/fragments/modal');
+    });
+
+    it('keeps description copy and its discount percentage when a link is authored inline (MWPW-207084)', async () => {
+      const a = document.createElement('a');
+      a.href = 'https://mas.adobe.com/studio.html#content-type=merch-card&fragment=inline-link-1&field=description-inline';
+      a.textContent = '[[inline-link-test:description]]';
+      document.body.append(a);
+      await init(a);
+      const masField = document.querySelector('mas-field');
+      expect(masField).to.exist;
+      const content = masField.querySelector('[data-role="mas-field-content"]');
+      expect(content).to.exist;
+      // The copy (carrying the discount percentage) survives instead of collapsing to the link.
+      expect(content.textContent).to.contain('Save 40% off your first year.');
+      expect(content.querySelector('a[href="https://www.adobe.com/terms"]')).to.exist;
+      expect(masField.querySelector('.con-button')).to.not.exist;
     });
 
     it('returns early for inline fragment when fragment is missing', async () => {

--- a/test/blocks/router-marquee/mocks/nested-paragraphs.html
+++ b/test/blocks/router-marquee/mocks/nested-paragraphs.html
@@ -1,0 +1,35 @@
+<main>
+  <div class="section">
+    <div class="router-marquee">
+      <div>
+        <div>mobile</div>
+      </div>
+      <div>
+        <div>
+          <p>Eyebrow one</p>
+          <h2>Slide one title</h2>
+          <p>Body copy for slide one. <mas-field field="prices"><span data-role="mas-field-content"></span></mas-field></p>
+          <p><em><strong><a href="https://www.adobe.com/buy">Buy now</a></strong></em></p>
+          <p><img src="/federal/icons/card-one.svg" alt="card one icon" /></p>
+          <p><a href="https://www.adobe.com/slide-one">Slide one</a></p>
+        </div>
+        <div>
+          <picture><img src="" alt="background one" /></picture>
+        </div>
+      </div>
+      <div>
+        <div>
+          <p>Eyebrow two</p>
+          <h2>Slide two title</h2>
+          <p>Body copy for slide two.</p>
+          <p><em><strong><a href="https://www.adobe.com/buy2">Buy now</a></strong></em></p>
+          <p><img src="/federal/icons/card-two.svg" alt="card two icon" /></p>
+          <p><a href="https://www.adobe.com/slide-two">Slide two</a></p>
+        </div>
+        <div>
+          <picture><img src="" alt="background two" /></picture>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/router-marquee/router-marquee.test.js
+++ b/test/blocks/router-marquee/router-marquee.test.js
@@ -121,6 +121,19 @@ describe('Router Marquee', () => {
     expect(cards[1].getAttribute('daa-ll')).to.equal('rm-nav-2--Slide two title');
   });
 
+  it('leaves paragraphs rendered inside a mas-field where they are', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/nested-paragraphs.html' });
+    const block = document.querySelector('.router-marquee');
+    // mas-field resolves before the block decorates and writes its own paragraphs
+    document.querySelector('mas-field [data-role="mas-field-content"]').innerHTML = '<p>A$9.99/mo</p><p>Terms apply.</p>';
+    init(block);
+
+    const body = mobileVp(block).querySelector('.rm-slide .rm-body');
+    expect(body.querySelectorAll(':scope > p').length).to.equal(1);
+    expect(body.querySelectorAll('mas-field p').length).to.equal(2);
+    expect(body.textContent.match(/A\$9\.99\/mo/g).length).to.equal(1);
+  });
+
   it('reorders slides based on the starting-marquee section metadata', async () => {
     document.body.innerHTML = await readFile({ path: './mocks/reorder.html' });
     const block = document.querySelector('.router-marquee');


### PR DESCRIPTION
## Why
Three related MAS-field fixes for merch and router-marquee, consolidated for review and release.

## What changed
- **MWPW-207084** — A field counts as a button only when the link is its whole content. Inline descriptions with a link (e.g. a "Terms apply" link) keep their full text, including the "Save X%" line.
- **MWPW-207231 / 207257** — `decorateText` collects only direct child paragraphs, so paragraphs a mas-field renders inside itself stay there instead of being hoisted into `.rm-body` and duplicated on the next render.
- **MWPW-207208** — A mas-field CTA that fires `mas:ready` after its block decorated is hoisted and decorated by one document listener, so late CTAs still hydrate.

## Test
Open each After URL and compare to Before.

- Inline description (MWPW-207084): open the Creative Cloud promo in the global navigation. The copy, discount percentage, and terms link all show.
  - Before: https://main--da-cc--adobecom.aem.page/creativecloud?instant=2028-08-13T19:30:00.000Z&country=ca
  - After: https://main--da-cc--adobecom.aem.page/creativecloud?instant=2028-08-13T19:30:00.000Z&country=ca&milolibs=MWPW-207303--milo--adobecom
- Router-marquee (MWPW-207231, MWPW-207208): paragraphs are not duplicated and CTAs render.
  - Before (sg): https://www.stage.adobe.com/?instant=2028-08-13T19:30:00.000Z&mep=off&country=sg&mas.preview=off
  - After (sg): https://www.stage.adobe.com/?instant=2028-08-13T19:30:00.000Z&mep=off&country=sg&mas.preview=off&milolibs=MWPW-207303
  - Before (au): https://www.stage.adobe.com/?instant=2028-08-13T19:30:00.000Z&mep=off&country=au&mas.preview=off
  - After (au): https://www.stage.adobe.com/?instant=2028-08-13T19:30:00.000Z&mep=off&country=au&mas.preview=off&milolibs=MWPW-207303
  - Before (upp draft): https://main--upp--adobecom.aem.page/au/drafts/mirafedas/?martech=off
  - After (upp draft): https://main--upp--adobecom.aem.page/au/drafts/mirafedas/?martech=off&milolibs=MWPW-207303

## Related issues
- Resolves [MWPW-207084](https://jira.corp.adobe.com/browse/MWPW-207084)
- Resolves [MWPW-207208](https://jira.corp.adobe.com/browse/MWPW-207208)
- Resolves [MWPW-207231](https://jira.corp.adobe.com/browse/MWPW-207231)
- Resolves [MWPW-207257](https://jira.corp.adobe.com/browse/MWPW-207257)



