### PR TITLE
MWPW-202977 [MEP] Enable insertion/replace of block rows or cells with fragments

### DIFF
--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -55,8 +55,22 @@ const updateFragMap = async (fragment, a, href) => {
 
 const insertInlineFrag = async (sections, a, relHref) => {
   // Inline fragments only support one section, other sections are ignored
-  const fragChildren = [...sections[0].children];
-  if (a.parentElement.nodeName === 'DIV' && !a.parentElement.attributes.length) {
+  const rowOrCellInsertContainer = a.closest('[data-mep-replace-type]');
+  const rowOrCellInsertValue = rowOrCellInsertContainer?.getAttribute('data-mep-replace-type');
+  const fragmentBlock = sections[0].querySelector('div[class]:not([class*="section"])');
+  let fragChildren;
+
+  if (rowOrCellInsertValue === 'row') {
+    fragChildren = fragmentBlock?.querySelectorAll(':scope > div') || [];
+  } else if (rowOrCellInsertValue === 'cell' && fragmentBlock) {
+    fragChildren = fragmentBlock?.querySelector(':scope > div')?.querySelectorAll(':scope > div') || [];
+  } else fragChildren = [...sections[0].children];
+  if (!fragChildren.length) return;
+
+  // if (rowOrCellInsertValue === 'cell' && !fragmentBlock) a.replaceWith(...fragChildren);
+  if (rowOrCellInsertContainer && fragmentBlock) {
+    rowOrCellInsertContainer.replaceWith(...fragChildren);
+  } else if (a.parentElement.nodeName === 'DIV' && !a.parentElement.attributes.length) {
     a.parentElement.replaceWith(...fragChildren);
   } else {
     a.replaceWith(...fragChildren);

--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -64,7 +64,9 @@ const insertInlineFrag = async (sections, a, relHref) => {
     fragChildren = fragmentBlock?.querySelectorAll(':scope > div') || [];
   } else if (rowOrCellInsertValue === 'cell' && fragmentBlock) {
     fragChildren = fragmentBlock?.querySelector(':scope > div')?.querySelectorAll(':scope > div') || [];
-  } else fragChildren = [...sections[0].children];
+  } else {
+    fragChildren = [...sections[0].children];
+  }
   if (!fragChildren.length) return;
 
   // if (rowOrCellInsertValue === 'cell' && !fragmentBlock) a.replaceWith(...fragChildren);
@@ -78,8 +80,16 @@ const insertInlineFrag = async (sections, a, relHref) => {
   const promises = [];
   fragChildren.forEach((child) => {
     child.setAttribute('data-path', relHref);
-    // Skip loadArea for MEP in-block replacements - gnav/footer have their own decoration
-    if (a.dataset.skipLoadArea !== 'true' && child.querySelector('a[href*="/fragments/"]')) {
+    const nestedFragments = child.querySelectorAll('a[href*="/fragments/"]');
+    if (a.dataset.skipLoadArea === 'true' || !nestedFragments.length) {
+      return;
+    }
+    if (rowOrCellInsertValue === 'row' || rowOrCellInsertValue === 'cell') {
+      nestedFragments.forEach((nestedFragment) => {
+        // eslint-disable-next-line no-use-before-define
+        promises.push(init(nestedFragment));
+      });
+    } else {
       promises.push(loadArea(child));
     }
   });

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -218,9 +218,23 @@ const createFrag = async (el, action, content, manifestId, targetManifestId) => 
   }
   const a = createTag('a', { href }, content);
   addIds(a, manifestId, targetManifestId);
-  const noParagraphWrap = !!el?.parentElement?.closest('p')
-    || (el.nodeName === 'P' && action.includes('pend'));
-  const frag = noParagraphWrap ? a : createTag('p', undefined, a);
+  let containerType = 'other';
+  const parent = el.parentElement;
+  const grandParent = el.parentElement?.parentElement;
+  if (parent?.nodeName === 'MAIN') containerType = 'section';
+  else if (parent?.nodeName === 'DIV' && parent?.classList.length && !parent?.classList.contains('section')) containerType = 'row';
+  else if (grandParent?.nodeName === 'DIV' && grandParent?.classList.length && !grandParent?.classList.contains('section')) containerType = 'cell';
+
+  const noParagraphWrap = !!el?.parentElement?.closest('p') // parent el is already inside a paragraph
+    || (el.nodeName === 'P' && action.includes('pend')) // parent el IS a p tag, AND you're prepending/appending
+    || containerType === 'row'
+    || containerType === 'cell';
+  // const frag = noParagraphWrap ? a : createTag('p', undefined, a);
+  let frag = a;
+
+  if (!noParagraphWrap) frag = createTag('p', undefined, frag);
+  if (containerType === 'row' || containerType === 'section') frag = createTag('div', undefined, frag);
+  if (containerType === 'row' || containerType === 'cell') frag = createTag('div', { 'data-mep-replace-type': containerType }, frag);
   const isDelayedModalAnchor = /#.*delay=/.test(href);
   if (isDelayedModalAnchor) frag.classList.add('hide-block');
   if (isInLcpSection(el)) {
@@ -257,8 +271,9 @@ export const createContent = async (
 
   const frag = await createFrag(el, action, content, manifestId, targetManifestId);
   addIds(frag, manifestId, targetManifestId);
-  if (el?.parentElement.nodeName !== 'MAIN') return frag;
-  return createTag('div', undefined, frag);
+  // if (el?.parentElement.nodeName !== 'MAIN') return frag;
+  // return createTag('div', undefined, frag);
+  return frag;
 };
 
 export const handleTwpButtons = (el, selector) => {

--- a/test/blocks/fragment/fragment.test.js
+++ b/test/blocks/fragment/fragment.test.js
@@ -123,6 +123,28 @@ describe('Fragments', () => {
     expect(marquee.innerHTML.includes('This marquee content is pulled from a fragment')).to.be.true;
   });
 
+  it('Resolves a fragment nested inside a row insert without leftover section wrappers', async () => {
+    const parent = document.createElement('div');
+    const rowContainer = document.createElement('div');
+    rowContainer.setAttribute('data-mep-replace-type', 'row');
+    const a = document.createElement('a');
+    a.href = '/test/blocks/fragment/mocks/fragments/row-insert#_inline';
+    rowContainer.appendChild(a);
+    parent.appendChild(rowContainer);
+    document.body.appendChild(parent);
+
+    await getFragment(a);
+
+    const row = parent.querySelector(':scope > div');
+    expect(row).to.exist;
+    expect(row.querySelector('.section')).to.not.exist;
+    expect(row.querySelector('[data-block]')).to.not.exist;
+    expect(row.innerHTML.includes('Nested cell content')).to.be.true;
+    expect(row.querySelector('[data-path*="nested-cell-content"]')).to.exist;
+
+    parent.remove();
+  });
+
   it('Does not inline fragments inside a block in DO_NOT_INLINE list', async () => {
     const cols = document.querySelector('.columns-section');
     await loadArea(cols);

--- a/test/blocks/fragment/mocks/fragments/nested-cell-content.plain.html
+++ b/test/blocks/fragment/mocks/fragments/nested-cell-content.plain.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Nested cell content</p>
+</div>

--- a/test/blocks/fragment/mocks/fragments/row-insert.plain.html
+++ b/test/blocks/fragment/mocks/fragments/row-insert.plain.html
@@ -1,0 +1,13 @@
+<div>
+  <div class="my-block">
+    <div>
+      <div>
+        <p>Row cell text</p>
+        <p><a href="/test/blocks/fragment/mocks/fragments/nested-cell-content#_inline">Nested</a></p>
+      </div>
+      <div>
+        <p>Second cell</p>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Summary
Enhance personalization fragment insertion for row and cell targets, including nested inline fragments.

Changes
- Updated personalization fragment creation to identify section, row, and cell insertion contexts.
- Preserve valid row and cell structure by avoiding paragraph wrappers where they are not appropriate.
- Add replacement container metadata with data-mep-replace-type for row and cell insertions.
- Update inline fragment handling to:
1. Extract the correct content from row and cell fragment structures.
2. Remove unnecessary section wrappers.
3. Resolve nested fragments within row and cell insertions.
4. Preserve existing behavior for standard fragment insertion and MEP in-block replacements.
- Added fragment unit coverage for nested content inserted into a row.
- Updated personalization functional test selectors to verify the actual replacement anchors rather than assuming they are descendants of a paragraph.

Resolves: [MWPW-202977](https://jira.corp.adobe.com/browse/MWPW-202977)

**Test URLs:**
- Before: https://main--upp--adobecom.aem.page/homepage/index-loggedout-fragmented?mep=%2Fdrafts%2Fmepdev%2Frowcol-feature-upp.json--hp-router-marquee
- After: https://main--upp--adobecom.aem.page/homepage/index-loggedout-fragmented?mep=%2Fdrafts%2Fmepdev%2Frowcol-feature-upp.json--hp-router-marquee&milolibs=mep-rowcol-v2

Compare the before and after link.  The before link has unintended behavior, but the after link cleanly replaces the row.
Before:
<img width="2067" height="1061" alt="image" src="https://github.com/user-attachments/assets/d7232419-8682-430d-a0b0-4e9bb619e317" />
After:
<img width="2074" height="1038" alt="image" src="https://github.com/user-attachments/assets/c08eb818-5bdf-40c5-80f5-3bb2bc4a1f04" />







