### PR TITLE
[MWPW-207415] - Fix ace1209 rich-content media padding/margin overrides

### DIFF
--- a/libs/mep/ace1209/rich-content/rich-content.css
+++ b/libs/mep/ace1209/rich-content/rich-content.css
@@ -495,10 +495,13 @@
   gap: var(--s2a-spacing-lg);
   padding-block: calc(var(--rc-media-spacing-top, var(--s2a-spacing-4xl)) + var(--rc-pull-offset)) var(--rc-media-spacing-bottom, var(--s2a-spacing-4xl));
   overflow: clip;
-  --grid-margin-width: 0px; /* Keep unit for calc */
 
-  @media (width >= 768px) {
-    --grid-margin-width: var(--grid-margin-width-base);
+  &.full-width {
+    --grid-margin-width: 0px; /* Keep unit for calc */
+
+    @media (width >= 768px) {
+      --grid-margin-width: var(--grid-margin-width-base);
+    }
   }
 
   .action-area {


### PR DESCRIPTION
## Title
Fix ace1209 rich-content media padding/margin overrides

## Summary
- Gate the media block's edge-to-edge bleed styling (border/radius removal, full-bleed image sizing) behind a `.full-width` modifier class instead of applying to all `.rich-content.media`
- Fix an invalid unscoped `--grid-margin-width` custom property declaration inside a bare `@media` block (no selector, so it was silently dropped by the parser) — rescoped it to `.rich-content.media.full-width` at the correct `>= 1280px` breakpoint
- Extend full-width media resets (border/radius/padding) to `picture`, not just `.video-container`, so full-width images get the same treatment as full-width video
- Drop the specificity of the block's default `padding-block` rule to zero via `:where()` so authored GWP spacing combo classes (e.g. `spacing-4xl`) can override the default padding, instead of losing to the block's own hardcoded rule

## Test plan
- [ ] Verify `.rich-content.media` renders with default padding at mobile/tablet/desktop breakpoints when no spacing class is authored
- [ ] Add a `spacing-4xl` (or similar) class to a `.rich-content.media` block and confirm the authored padding now overrides the default
- [ ] Verify `.rich-content.media.full-width` bleeds edge-to-edge with the correct `--grid-margin-width` reset at `>= 1280px`
- [ ] Verify non-`full-width` media blocks are unaffected by the bleed styling
- [ ] Verify full-width `picture` images get the same border/radius/aspect-ratio treatment as full-width video


Resolves: [MWPW-207415](https://jira.corp.adobe.com/browse/MWPW-207415)

**Mobile video Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=stage
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=rich-content-media-reconcile

**Mobile image Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/drafts/dusan/test-img-full-width-media-rc?milolibs=stage
- After: https://main--da-cc--adobecom.aem.page/drafts/dusan/test-img-full-width-media-rc?milolibs=rich-content-media-reconcile


